### PR TITLE
Add reactoring BuildRequestUrl()

### DIFF
--- a/src/nt-sms/Triggers/GetMessage.cs
+++ b/src/nt-sms/Triggers/GetMessage.cs
@@ -23,6 +23,7 @@ using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
 using Toast.Sms.Configurations;
+using Toast.Sms.Examples;
 using Toast.Sms.Models;
 using Toast.Sms.Validators;
 using Toast.Sms.Workflows;
@@ -65,7 +66,7 @@ namespace Toast.Sms.Triggers
 
             var workflow = new HttpTriggerWorkflow();
             await workflow.ValidateHeaderAsync(req)
-                          .ValidateQueriesAsync(req, this._validator)
+                          .ValidateQueriesAsync<GetMessageRequestQueries>(req, this._validator)
                           .ConfigureAwait(false);
 
             var headers = default(RequestHeaderModel);

--- a/src/nt-sms/Workflows/HttpTriggerWorkflow.cs
+++ b/src/nt-sms/Workflows/HttpTriggerWorkflow.cs
@@ -9,10 +9,12 @@ using FluentValidation;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-
+using Toast.Common.Builders;
+using Toast.Common.Configurations;
 using Toast.Common.Extensions;
 using Toast.Common.Models;
 using Toast.Common.Validators;
+using Toast.Sms.Configurations;
 using Toast.Sms.Validators;
 
 namespace Toast.Sms.Workflows
@@ -30,6 +32,8 @@ namespace Toast.Sms.Workflows
         Task<IHttpTriggerWorkflow> ValidateHeaderAsync(HttpRequest req);
 
         Task<IHttpTriggerWorkflow> ValidateQueriesAsync<T>(HttpRequest req, IValidator<T> validator) where T : BaseRequestQueries;
+    
+        Task<IHttpTriggerWorkflow> BuildRequestUrl<Tresult>(ToastSettings<SmsEndpointSettings> settings, BaseRequestPaths paths = null);
     }
 
     /// <summary>
@@ -39,6 +43,8 @@ namespace Toast.Sms.Workflows
     {
         private RequestHeaderModel _headers;
         private BaseRequestQueries _queries;
+
+        private string _requestUrl;
 
         /// <inheritdoc />
         public async Task<IHttpTriggerWorkflow> ValidateHeaderAsync(HttpRequest req)
@@ -61,5 +67,22 @@ namespace Toast.Sms.Workflows
 
             return await Task.FromResult(this).ConfigureAwait(false);
         }
+
+        public async Task<IHttpTriggerWorkflow> BuildRequestUrl<Tresult>(ToastSettings<SmsEndpointSettings> settings, BaseRequestPaths paths = null) {
+            // var paths = new GetMessageRequestPaths() { RequestId = requestId };
+
+            var _endpoint = nameof(Tresult);
+
+            var requestUrl = new RequestUrlBuilder()
+                .WithSettings(settings, _endpoint)
+                .WithHeaders(_headers) 
+                .WithQueries(_queries)
+                .WithPaths(paths).Build();
+
+            this._requestUrl = requestUrl;
+ 
+            return await Task.FromResult(this).ConfigureAwait(false);   
+        }
+
     }
 }


### PR DESCRIPTION
[#63](https://github.com/devrel-kr/nhn-toast-notification-service-custom-connector/issues/63)

BuildRequestUrl() 리팩토링한 코드를 올립니다. 

 Build()에서 path나 queries가 null일 때 처리해주는 코드가 존재하기 때문에 파라미터의 path를 null로 초기화했습니다. 