### PR TITLE
Modify ValidateHeaderTest in HttpWorkflowTest.cs

### DIFF
--- a/test/NhnToast.Sms.Tests/Workflows/HttpTriggerWorkflowTests.cs
+++ b/test/NhnToast.Sms.Tests/Workflows/HttpTriggerWorkflowTests.cs
@@ -64,7 +64,7 @@ namespace Toast.Sms.Tests.Workflows
         }
 
         [TestMethod]
-        public async Task Given_NullHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_ExceptionAsync()
+        public async Task Given_NullHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_NullReferenceException()
         {
             var req = new Mock<HttpRequest>();
             var workflow = new HttpTriggerWorkflow(this._factory.Object, this._fomatter.Object);
@@ -75,7 +75,7 @@ namespace Toast.Sms.Tests.Workflows
         }
 
         [TestMethod]
-        public void Given_NoHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_Exception()
+        public async Task Given_NoHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_InvalidOperationException()
         {
             var headers = new HeaderDictionary();
             headers.Add("Authorization", "Basic");
@@ -87,13 +87,14 @@ namespace Toast.Sms.Tests.Workflows
 
             Func<Task> func = async () => await workflow.ValidateHeaderAsync(req.Object);
 
-            func.Should().ThrowAsync<RequestHeaderNotValidException>();
+            await func.Should().ThrowAsync<InvalidOperationException>();
+
         }
 
         [DataTestMethod]
-        [DataRow("hello", null)]
-        [DataRow(null, "world")]
-        public void Given_InvalidHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_Exception(string username, string password)
+        [DataRow("hello", " ")]
+        [DataRow(" ", "world")]
+        public async Task Given_InvalidHeader_When_Invoke_ValidateHeaderAsync_Then_It_Should_Throw_Exception(string username, string password)
         {
             var bytes = Encoding.UTF8.GetBytes($"{username}:{password}");
             var encoded = Convert.ToBase64String(bytes);
@@ -108,7 +109,7 @@ namespace Toast.Sms.Tests.Workflows
 
             Func<Task> func = async () => await workflow.ValidateHeaderAsync(req.Object);
 
-            func.Should().ThrowAsync<RequestHeaderNotValidException>();
+            await func.Should().ThrowAsync<RequestHeaderNotValidException>();
         }
 
         [DataTestMethod]


### PR DESCRIPTION
 ValidateHeader 부분을 모두 알맞게 수정하였습니다. 

### 1. 문제 파악 
테스트를 해본 결과 
```csharp
public static T To<T>(this HttpRequest req, bool useBasicAuthHeader) where T : RequestHeaderModel
        {
            var values = req.Headers["Authorization"]
                            .ToString()
                            .Replace("Basic", string.Empty)
                            .Trim()
                            .Decode()
                            .Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries)
                            .ToArray();

            var headers = new RequestHeaderModel() { AppKey = values.First(), SecretKey = values.Last() };

            return (T)headers;
        }
```
- NullHeader의 경우 Mock<HttpRequest>에서 Headers를 찾을 수 없기에 NullReference 에러가 발생하였습니다. 
- NoHeader의 경우 var headers = new RequestHeaderModel() { AppKey = values.First(), SecretKey = values.Last() }; 에서 InvalidOperation 에러가 발생하였습니다. 
- InvalidHeader의 경우에도 InvalidOperation 에러가 발생하였습니다. 

### 2. 분석 및 해결 - [링크](https://velog.io/@juijeong8324/OSSCA-63-5)에 들어가보면 더 자세한 해결과정을 볼 수 있습니다. 
- InvalidHeader의 경우, null값이 입력되면 StringSplitOptions.RemoveEmptyEntries에서 배열에 null값을 제외시키기 때문에 발생하는 문제였습니다 따라서 데이터를 null or ""이 아닌 " " whitespace로 입력하여 해결해주었습니다.   
- NoHeader의 경우에도 InvalidHeader test의 문제와 비슷한 경우이기 때문에 RequestHeaderNotValidException이 아닌 InvalidOperationException을 잡도록 수정하였습니다. 